### PR TITLE
Fix: 増減目インジケータを変更が発生する段に正確に表示 (#5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,19 +258,17 @@
             const stitchChange = parseInt(settingStitchCountInput.value) || 0;
             const stitchInterval = parseInt(settingStitchInput.value) || 1;
             
-            const nextRow = currentRow + 1;
-            
-            if (stitchInterval > 0 && nextRow % stitchInterval === 0) {
+            if (stitchInterval > 0 && currentRow > 0 && currentRow % stitchInterval === 0) {
                 if (stitchChange > 0) {
                     rowGroup.classList.remove('decrease');
                     rowGroup.classList.add('increase');
-                    stitchChangeIndicator.textContent = `+${stitchChange}`;
+                    stitchChangeIndicator.textContent = `+${stitchChange}目`;
                     stitchChangeIndicator.className = 'stitch-indicator';
                     stitchChangeIndicator.style.display = 'flex';
                 } else if (stitchChange < 0) {
                     rowGroup.classList.remove('increase');
                     rowGroup.classList.add('decrease');
-                    stitchChangeIndicator.textContent = `${stitchChange}`;
+                    stitchChangeIndicator.textContent = `${stitchChange}目`;
                     stitchChangeIndicator.className = 'stitch-indicator';
                     stitchChangeIndicator.style.display = 'flex';
                 } else {


### PR DESCRIPTION
## 概要
Issue #5 の修正: 増減目インジケータが変更発生の段に正確に表示されるように修正しました。

## 変更内容
- インジケータを次の段ではなく、実際に変更が発生する段（`currentRow % stitchInterval === 0`）に表示するように修正
- インジケータに「目」の単位を追加（例：`+2目`、`-2目`）
- `currentRow > 0` のチェックを追加して初期状態での誤表示を防止

## テスト方法
1. 編み物カウンターを開く
2. 目数設定で「2目 / 2段ごと」などに設定
3. DONEボタンをクリックして段数を進める
4. 変更が発生する段（2段目、4段目など）に正確にインジケータが表示されることを確認

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)