### PR TITLE
デザイン微調整

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -419,7 +419,7 @@ body {
 
 @media (max-width: 480px) {
     body {
-        padding: 40px 20px;
+        padding: 40px 30px;
     }
 
     .container {

--- a/styles.css
+++ b/styles.css
@@ -285,8 +285,8 @@ body {
     width: 180px;
     margin: 10px auto;
     box-shadow:
-        inset 2px 0 0 rgba(255, 255, 255, 0.6),
-        inset 0 2px 0 rgba(255, 255, 255, 0.6),
+        inset 2px 0 0 rgba(255, 255, 255, 0.4),
+        inset 0 2px 0 rgba(255, 255, 255, 0.4),
         inset -2px 0 0 rgba(255, 255, 255, 0.1),
         inset 0 -2px 0 rgba(255, 255, 255, 0.1),
         6px 6px 10px 0px rgba(0, 0, 0, 0.3);

--- a/styles.css
+++ b/styles.css
@@ -283,7 +283,7 @@ body {
     border-radius: 100px;
     padding: 16px 10px;
     width: 180px;
-    margin: 0 auto;
+    margin: 10px auto;
     box-shadow:
         inset 2px 0 0 rgba(255, 255, 255, 0.6),
         inset 0 2px 0 rgba(255, 255, 255, 0.6),

--- a/styles.css
+++ b/styles.css
@@ -176,7 +176,7 @@ body {
 
 .counter-section.increase {
     background: linear-gradient(
-        135deg,
+        180deg,
         rgba(46, 125, 50, 0.5) 0%,
         rgba(46, 125, 50, 0.35) 50%,
         rgba(46, 125, 50, 0.25) 100%
@@ -185,7 +185,7 @@ body {
 
 .counter-section.decrease {
     background: linear-gradient(
-        135deg,
+        180deg,
         rgba(198, 40, 40, 0.5) 0%,
         rgba(198, 40, 40, 0.35) 50%,
         rgba(198, 40, 40, 0.25) 100%

--- a/styles.css
+++ b/styles.css
@@ -281,8 +281,8 @@ body {
     color: white;
     border: 1px solid rgba(107, 68, 35, 0.2);
     border-radius: 100px;
-    padding: 20px 10px;
-    width: 200px;
+    padding: 16px 10px;
+    width: 180px;
     margin: 0 auto;
     box-shadow:
         inset 2px 0 0 rgba(255, 255, 255, 0.6),
@@ -317,7 +317,7 @@ body {
 .done-button span,
 .done-button {
     font-family: 'Bricolage Grotesque', sans-serif;
-    font-size: 24px;
+    font-size: 20px;
     font-weight: 800;
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- 増し目/減らし目の赤/緑の背景色グラデーションを上→下方向(180deg)に変更
- DONEボタンを少し小さくする（padding、width、font-size調整）
- DONEボタンの上下マージンを追加
- DONEボタンの左上ハイライトのalphaを薄くする
- スマホ表示時の左右マージンを増やす

Closes #14

## Test plan
- [ ] 増し目/減らし目のグラデーション方向が上→下になっていること
- [ ] DONEボタンが以前より少し小さくなっていること
- [ ] DONEボタンの上下に適切な余白があること
- [ ] DONEボタンのハイライトが控えめになっていること
- [ ] スマホ表示時に左右の余白が適切にあること

🤖 Generated with [Claude Code](https://claude.com/claude-code)