### PR TITLE
iPhoneのステータスバー（ノッチ周り）の色を設定

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="theme-color" content="#f2f1ed">
     <title>編み物カウンター</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- `<meta name="theme-color" content="#f2f1ed">` を追加してiPhoneのステータスバー（ノッチ周り）の色を設定

Closes #16

## Test plan
- [ ] iPhoneでホーム画面に追加して、ステータスバーの色が `#f2f1ed` になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)