### PR TITLE
style: theme-colorを#f0ede7に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="theme-color" content="#f2f1ed">
+    <meta name="theme-color" content="#f0ede7">
     <title>編み物カウンター</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- iPhoneのステータスバー（ノッチ周り）の `theme-color` を `#f2f1ed` → `#f0ede7` に変更

## Test plan
- [ ] iPhoneでホーム画面に追加して、ステータスバーの色が `#f0ede7` になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)